### PR TITLE
Ensure that Docker Build don't get JS restore errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,6 @@
 .gitignore
 .vs
 .vscode
-*/bin
-*/obj
+**/bin
+**/obj
 **/.toolstarget

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.1" />


### PR DESCRIPTION
- NuGet package was causing an error as `cdnjs` API had changed.
- Make sure `bin\` and `obj\` folders at any level are ignored by `docker compose build` by default.